### PR TITLE
update bridge indexer url for devnet c1

### DIFF
--- a/packages/milkomeda-wsc/src/MilkomedaConstants.ts
+++ b/packages/milkomeda-wsc/src/MilkomedaConstants.ts
@@ -127,7 +127,7 @@ export class MilkomedaConstants {
       case MilkomedaNetworkName.C1Mainnet:
         return "https://ada-bridge-mainnet-cardano-evm-us.c1.milkomeda.com/api/v1";
       case MilkomedaNetworkName.C1Devnet:
-        return "https://ada-bridge-devnet-cardano-evm.c1.milkomeda.com/api/v1";
+        return "https://ada-bridge-devnet-cardano-evm-c1.milkomeda.com/api/v1";
       case MilkomedaNetworkName.A1Mainnet:
         return "https://algo-bridge-mainnet-algorand-rollup.a1.milkomeda.com/api/v1";
       case MilkomedaNetworkName.A1Devnet:


### PR DESCRIPTION
We redeployed fixed `bridge indexer` (backend/core for bridge explorer) for `Devnet C1` and fastest way to provide new url is to add that whenever it's used 