### PR TITLE
Remove more instances of windows.ethereum

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -12,7 +12,8 @@ The provider customizes few json-rpc methods like `eth_sendTransaction`, `eth_re
 ```typescript
 const oldProvider = window.ethereum;
 const provider = await import("provider");
-await provider.inject(oracleUrl, nodeUrl).setup();
+const injectedProvider = provider.inject(oracleUrl, nodeUrl);
+await injectedProvider.setup();
 ```
 
 To switch back to the old provider, for example the MetaMask.
@@ -20,6 +21,10 @@ To switch back to the old provider, for example the MetaMask.
 ```typescript
 window.ethereum = oldProvider;
 ```
+
+Note that there is no guarantee another wallet doesn't come and replace the `window.ethereum` object, so you cannot assume that it always points to the WSC provider. Therefore, to keep a reference to the new WSC provider, you have two options:
+1. Keep a reference to the new provider (`injectedProvider`)
+2. Use [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) to query the provider at a later date
 
 ## Actor Address
 
@@ -46,11 +51,12 @@ import { ethers } from "ethers";
 import { Blockfrost, Lucid } from "lucid-cardano";
 
 const milkomedaProvider = await import("provider");
-await milkomedaProvider.inject(oracleUrl, nodeUrl).setup();
+const injectedProvider = milkomedaProvider.inject(oracleUrl, nodeUrl);
+await injectedProvider.setup();
 
 const amount = 10;
 
-const provider = new ethers.providers.Web3Provider(window.ethereum);
+const provider = new ethers.providers.Web3Provider(injectedProvider);
 
 const signer = provider.getSigner();
 const actorAddress = await signer.getAddress();
@@ -79,11 +85,12 @@ const txHash = await signedTx.submit();
 import { ethers } from "ethers";
 
 const milkomedaProvider = await import("provider");
-await milkomedaProvider.inject(oracleUrl, nodeUrl).setup();
+const injectedProvider = milkomedaProvider.inject(oracleUrl, nodeUrl);
+await injectedProvider.setup();
 
 const amount = 10;
 
-const provider = new ethers.providers.Web3Provider(window.ethereum);
+const provider = new ethers.providers.Web3Provider(injectedProvider);
 
 const signer = provider.getSigner();
 
@@ -103,11 +110,12 @@ const receipt = await tx.wait();
 import { ethers } from "ethers";
 
 const milkomedaProvider = await import("provider");
-await milkomedaProvider.inject(oracleUrl, nodeUrl).setup();
+const injectedProvider = milkomedaProvider.inject(oracleUrl, nodeUrl);
+await injectedProvider.setup();
 
 const amount = 10;
 
-const provider = new ethers.providers.Web3Provider(window.ethereum);
+const provider = new ethers.providers.Web3Provider(injectedProvider);
 
 const signer = provider.getSigner();
 

--- a/packages/dapp-example/src/App.tsx
+++ b/packages/dapp-example/src/App.tsx
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import type { MilkomedaProvider } from "milkomeda-wsc-provider";
 import React from "react";
 import { Link } from "react-router-dom";
 
@@ -6,26 +7,30 @@ import { Link } from "react-router-dom";
 const COUNTER_ADDRESS = "0000000000000000000000000000000000222222";
 
 const App = () => {
+  const [injectedProvider, setInjectedProvider] = React.useState<undefined | MilkomedaProvider>();
   const injectCardano = async () => {
     const provider = await import("milkomeda-wsc-provider");
-    await provider
-      .injectCardano("http://localhost:8080", "https://rpc-devnet-cardano-evm.c1.milkomeda.com")
-      .setup(1);
+    const injectedProvider = provider
+      .injectCardano("http://localhost:8080", "https://rpc-devnet-cardano-evm.c1.milkomeda.com");
+    setInjectedProvider(injectedProvider);
+    await injectedProvider.setup(1);
 
     alert("Injected");
   };
 
   const injectAlgorand = async () => {
     const provider = await import("milkomeda-wsc-provider");
-    await provider
-      .injectAlgorand("http://localhost:8080", "https://rpc-devnet-cardano-evm.c1.milkomeda.com")
-      .setup();
+    const injectedProvider = provider
+      .injectAlgorand("http://localhost:8080", "https://rpc-devnet-cardano-evm.c1.milkomeda.com");
+    setInjectedProvider(injectedProvider);
+    await injectedProvider.setup();
 
     alert("Injected");
   };
 
   const eth_requestAccounts = async () => {
-    const result = (await window.ethereum.request({
+    if (injectedProvider == null) alert("Provider not injected");
+    const result = (await injectedProvider.request({
       method: "eth_requestAccounts",
       params: [],
     })) as string[];
@@ -34,26 +39,30 @@ const App = () => {
   };
 
   const eth_accounts = async () => {
-    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    if (injectedProvider == null) alert("Provider not injected");
+    const provider = new ethers.providers.Web3Provider(injectedProvider);
     const accounts = await provider.listAccounts();
     alert(accounts);
   };
 
   const eth_blockNumber = async () => {
-    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    if (injectedProvider == null) alert("Provider not injected");
+    const provider = new ethers.providers.Web3Provider(injectedProvider);
     const blockNumber = await provider.getBlockNumber();
     alert(blockNumber);
   };
 
   const eth_getBalance = async () => {
-    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    if (injectedProvider == null) alert("Provider not injected");
+    const provider = new ethers.providers.Web3Provider(injectedProvider);
     const signer = provider.getSigner();
     const balance = await provider.getBalance(signer.getAddress());
     alert(ethers.utils.formatEther(balance));
   };
 
   const sendEther = async () => {
-    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    if (injectedProvider == null) alert("Provider not injected");
+    const provider = new ethers.providers.Web3Provider(injectedProvider);
     const signer = provider.getSigner();
 
     const receiverAddress = prompt("Receiver address");
@@ -69,7 +78,8 @@ const App = () => {
   };
 
   const getCounter = async () => {
-    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    if (injectedProvider == null) alert("Provider not injected");
+    const provider = new ethers.providers.Web3Provider(injectedProvider);
     const counter = new ethers.Contract(
       COUNTER_ADDRESS,
       ["function count() view returns (uint256)", "function increment(uint256)"],
@@ -80,7 +90,8 @@ const App = () => {
   };
 
   const incrementCounter = async () => {
-    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    if (injectedProvider == null) alert("Provider not injected");
+    const provider = new ethers.providers.Web3Provider(injectedProvider);
     const counter = new ethers.Contract(
       COUNTER_ADDRESS,
       ["function count() view returns (uint256)", "function increment(uint256)"],

--- a/packages/milkomeda-wsc/src/wscLib.ts
+++ b/packages/milkomeda-wsc/src/wscLib.ts
@@ -174,8 +174,8 @@ export class WSCLib {
   }
 
   async eth_requestAccounts(): Promise<string> {
-    if (window.ethereum == null) throw new Error("Provider not loaded");
-    const result = (await window.ethereum.request({
+    if (this.wscProvider == null) throw new Error("Provider not loaded");
+    const result = (await this.wscProvider.request({
       method: "eth_requestAccounts",
       params: [],
     })) as string[];
@@ -196,8 +196,8 @@ export class WSCLib {
   }
 
   async getEthersProvider(): Promise<ethers.providers.Web3Provider> {
-    if (!window.ethereum) throw "Provider not loaded";
-    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    if (!this.wscProvider) throw "Provider not loaded";
+    const provider = new ethers.providers.Web3Provider(this.wscProvider);
     if (this.isAlgorand()) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (provider.provider as any).peraWallet.chainId = this.peraWallet?.chainId;


### PR DESCRIPTION
Phantom intercepts any call to setting `window.ethereum` to stop them from replacing Phantom. That means we cannot use `window.ethereum` anywhere in the code and have to keep a reference to the WSC provider otherwise Phantom will get used instead of WSC causing issues